### PR TITLE
Windows compatibility

### DIFF
--- a/requirements/base.pip
+++ b/requirements/base.pip
@@ -16,5 +16,5 @@ pandas
 pydantic
 
 #
-pyconfr-2019-grpc-nlp-tools>=0.1.4
+pyconfr-2019-grpc-nlp-tools>=0.1.5
 pyconfr-2019-grpc-nlp-protos>=0.1.2

--- a/src/tweet_features/tweet_features_server.py
+++ b/src/tweet_features/tweet_features_server.py
@@ -17,7 +17,7 @@ logger = logging.getLogger(__name__)
 
 def serve(block=True,
           grpc_host_and_port=os.environ.get(
-              "TWITTER_ANALYZER_FEATURES_GRPC_HOST_AND_PORT", '[::]:50051')):
+              "TWITTER_ANALYZER_FEATURES_GRPC_HOST_AND_PORT", 'localhost:50051')):
     """
     Start a new instance of the features processing service.
 
@@ -30,7 +30,7 @@ def serve(block=True,
     :param grpc_host_and_port: Listening address of the server.
                                Defaults to the content of the
                                ``TWITTER_ANALYZER_FEATURES_GRPC_HOST_AND_PORT``
-                               environment variable, or ``[::]:50052`` if not set
+                               environment variable, or ``localhost:50052`` if not set
     :type grpc_host_and_port: str
 
     :return: If ``block`` is True, return nothing.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -115,7 +115,7 @@ def mocked_tweet_features_rpc_server(mocker, free_port_for_grpc_server):
                 mock_tweet_features.return_value.__enter__.return_value = database
 
             if _cache_grpc["server_instance"] is None:
-                _cache_grpc["grpc_host_and_port"] = "[::]:{}".format(free_port_for_grpc_server)
+                _cache_grpc["grpc_host_and_port"] = "localhost:{}".format(free_port_for_grpc_server)
                 _cache_grpc["server_instance"] = serve(block=False,
                                                        grpc_host_and_port=_cache_grpc["grpc_host_and_port"])
                 assert _cache_grpc["server_instance"] is not None


### PR DESCRIPTION
# Actions

- update tools package requirements: `pyconfr-2019-grpc-nlp-tools>=0.1.5`
- in unit test: replace grpc host '[::]' to 'localhost' (to be compatible on windows)
